### PR TITLE
fix: allow units for 0 values on custom properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3369,8 +3369,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3391,14 +3390,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3413,20 +3410,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3543,8 +3537,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3556,7 +3549,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3571,7 +3563,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3579,14 +3570,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3605,7 +3594,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3686,8 +3674,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3699,7 +3686,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3785,8 +3771,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3822,7 +3807,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3842,7 +3826,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3886,14 +3869,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/rules/base.js
+++ b/rules/base.js
@@ -65,7 +65,9 @@ module.exports = {
         'no-missing-end-of-source-newline': true,
         'number-leading-zero': 'always',
         'number-no-trailing-zeros': true,
-        'length-zero-no-unit': true,
+        'length-zero-no-unit': [true, {
+            'ignore': 'custom-properties',
+        }],
         'property-no-vendor-prefix': true,
         'rule-empty-line-before': ['always-multi-line', {
             'except': ['first-nested'],

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -74,6 +74,12 @@ Array [
     "rule": "comment-empty-line-before",
     "severity": "error",
   },
+  Object {
+    "column": 18,
+    "line": 55,
+    "rule": "length-zero-no-unit",
+    "severity": "error",
+  },
 ]
 `;
 

--- a/test/fixtures/basic.bad.css
+++ b/test/fixtures/basic.bad.css
@@ -50,3 +50,7 @@
    line
    comment
 */
+
+h1 {
+    margin-top: 0px;
+}

--- a/test/fixtures/basic.good.css
+++ b/test/fixtures/basic.good.css
@@ -4,6 +4,10 @@
 @mixin foo .foo;
 @mixin bar .foo;
 
+:root {
+    --zero-unit-var: 0px;
+}
+
 .foo {
     @mixin foo;
     display: block;


### PR DESCRIPTION
Allow units for 0 values on custom properties.

This fixes the issue of using custom properties with value zero in `calc` expressions (zero without units breaks it).