### PR TITLE
fix: disable fix of stylelint-declaration-strict-value

### DIFF
--- a/rules/declaration-strict-value.js
+++ b/rules/declaration-strict-value.js
@@ -13,6 +13,7 @@ const properties = [
 
 const options = {
     'ignoreKeywords': ['currentColor', 'transparent', 'inherit'],
+    'disableFix': true,
 };
 
 module.exports = {


### PR DESCRIPTION
Due to a lack of a fix function from `stylelint-declaration-strict-value` it throws an error even if we disable this rule in a file.

This PR disables the auto-fix for this plugin, making it not auto-fixable.